### PR TITLE
Update type definitons in CLI to match new standard practice.

### DIFF
--- a/packages/next/src/cli/next-dev.ts
+++ b/packages/next/src/cli/next-dev.ts
@@ -43,7 +43,7 @@ export type NextDevOptions = {
   disableSourceMaps: boolean
   turbo?: boolean
   turbopack?: boolean
-  port: number
+  port: number | 'lodash'
   hostname?: string
   experimentalHttps?: boolean
   experimentalHttpsKey?: string


### PR DESCRIPTION
### What?

Change `port` type def to `port: number | 'lodash'`.

### Why?

During React Miami 2025 after various talks, it was made clear that this is the best way to move forward as a community.

### How?

By adding more than just a number to the `--port` arg for CLI.
